### PR TITLE
Add types build script and declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,16 @@
   "version": "3.2.9",
   "description": "Jodit is awesome and usefully wysiwyg editor with filebrowser",
   "main": "build/jodit.min.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "newversion": "npm test && npm version patch --no-git-tag-version && npm run build && npm run newversiongit && npm publish ./",
     "newversiongit": "git add --all  && git commit -m \"New version %npm_package_version%. Read more https://github.com/xdan/jodit/releases/tag/%npm_package_version% \" && git tag %npm_package_version% && git push --tags origin HEAD:master",
     "start": "node server.js",
-    "build": "rm -f build/* && cross-env NODE_ENV=production webpack --progress  && npm run build-no-uglify",
+    "build": "rm -f build/* && cross-env NODE_ENV=production webpack --progress  && npm run build-no-uglify && npm run types",
     "build-no-uglify": "cross-env NODE_ENV=production-no-uflify webpack --progress",
     "test": "karma start --browsers Firefox karma.conf.js --single-run",
-    "jodit": "cd ../jodit-angular/ && npm run newversion && cd ../jodit-joomla && npm run newversion && cd ../jodit-docs && npm run newversion"
+    "jodit": "cd ../jodit-angular/ && npm run newversion && cd ../jodit-joomla && npm run newversion && cd ../jodit-docs && npm run newversion",
+    "types": "rm -rf types/* && tsc --project . --declaration --outDir types --emitDeclarationOnly"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #79
I did not add the `types` directory to `.gitignore` because it looks like this project keeps the build output in GitHub.
