### PR TITLE
Added a link insertion as its title

### DIFF
--- a/src/plugins/link.ts
+++ b/src/plugins/link.ts
@@ -182,7 +182,11 @@ Config.prototype.controls.link = {
 			a.setAttribute('href', url_input.value);
 
 			if (!isImageContent) {
-				a.textContent = content_input.value;
+				if (content_input.value.trim().length) {
+					a.textContent = content_input.value;
+				} else {
+					a.textContent = url_input.value;
+				}
 			}
 
 			if (openInNewTabCheckbox) {


### PR DESCRIPTION
Added insertion of a link in the link title if the user has not specified its text

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes: Added a link insertion as its title (instead of an empty title), if at its user did not specify a title in the link creation dialog

Добавил вставку ссылки и в качестве ее заголовка (вместо пустого заголовка), если при ее пользователь не указал заголовок в диалоге создания ссылки