### PR TITLE
Update jodit.js

### DIFF
--- a/build/jodit.js
+++ b/build/jodit.js
@@ -8366,8 +8366,8 @@ function paste(editor) {
                 return '';
             };
             var clipboard_html = getText();
-            if (Dom_1.Dom.isNode(clipboard_html, editor.editorWindow) ||
-                helpers_1.trim(clipboard_html) !== '') {
+            if (clipboard_html != null && (Dom_1.Dom.isNode(clipboard_html, editor.editorWindow) ||
+                helpers_1.trim(clipboard_html) !== '')) {
                 clipboard_html = trimFragment(clipboard_html);
                 var buffer = editor.buffer.get(cut_1.pluginKey);
                 if (buffer !== clipboard_html) {


### PR DESCRIPTION
This should fix the bug that avoids afterpaste event to trigger on IE11 when an image is pasted

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
