### PR TITLE
Update paste.ts instead of jodit.js (IE11 text paste)

### DIFF
--- a/src/plugins/clipboard/paste.ts
+++ b/src/plugins/clipboard/paste.ts
@@ -250,7 +250,8 @@ export function paste(editor: IJodit) {
 			editor.buffer.set(clipboardPluginKey, html);
 		}
 
-		editor.selection.insertHTML(html);
+		//editor.selection.insertHTML(html);           //looks like other instructions already do this (waitData_1 for example).
+		                                               //Plus, here the selection seems to be at the wrong place 
 	};
 
 	const insertHTML = (
@@ -488,7 +489,7 @@ export function paste(editor: IJodit) {
 				event.preventDefault();
 				return false;
 			}
-
+      const preventDefault = true;                       //need this to disable preventdefault when pasting text
 			const dt = getDataTransfer(event);
 
 			if (event && dt) {
@@ -574,10 +575,12 @@ export function paste(editor: IJodit) {
 						}
 
 						insertByType(clipboard_html, opt.defaultActionOnPaste);
+						preventDefault = false;                //so that the pasting process will be executed by waitData_1 inside beforePaste
 					}
-
-					event.preventDefault();
-					event.stopPropagation();
+          if (preventDefault){
+					  event.preventDefault();
+					  event.stopPropagation();
+					}
 				}
 			}
 


### PR DESCRIPTION
I had the time to try it on chrome and it works fine there too.

[X] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[X] Code is up-to-date with the `master` branch
[X] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

pasting some text on IE11 was resulting in it being added at the start of the document instead of at the selection cursor