### PR TITLE
Fix TS build errors (Fixes #358)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,8 +139,7 @@
 		"@types/ace": {
 			"version": "0.0.42",
 			"resolved": "https://registry.npmjs.org/@types/ace/-/ace-0.0.42.tgz",
-			"integrity": "sha512-ZakacqExJnGSoz0fSFtSL1A1Df+MIqTIPBBMl1ppEU8wS5AWGx0EPQPOyiAazkyMrskI0iG16tT+K1ZmIJGGnA==",
-			"dev": true
+			"integrity": "sha512-ZakacqExJnGSoz0fSFtSL1A1Df+MIqTIPBBMl1ppEU8wS5AWGx0EPQPOyiAazkyMrskI0iG16tT+K1ZmIJGGnA=="
 		},
 		"@types/es6-promise": {
 			"version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 	},
 	"homepage": "https://xdsoft.net/jodit/",
 	"devDependencies": {
-		"@types/ace": "0.0.42",
 		"@types/es6-promise": "^3.3.0",
 		"@types/node": "^12.12.26",
 		"autoprefixer": "^6.7.7",
@@ -111,6 +110,7 @@
 		]
 	},
 	"dependencies": {
+		"@types/ace": "0.0.42",
 		"chai": "^4.2.0",
 		"gulp-typescript": "^5.0.1",
 		"mocha": "^7.0.1"

--- a/src/modules/helpers/JoditArray.ts
+++ b/src/modules/helpers/JoditArray.ts
@@ -10,7 +10,7 @@ export class JoditArray {
 	length: number = 0;
 
 	toString() {
-		const out = [];
+		const out: any[] = [];
 
 		for (let i = 0; i < this.length; i += 1) {
 			out[i] = (this as any)[i];

--- a/src/plugins/source/editor/engines/ace.ts
+++ b/src/plugins/source/editor/engines/ace.ts
@@ -4,7 +4,6 @@
  * Copyright (c) 2013-2020 Valeriy Chupurnov. All rights reserved. https://xdsoft.net
  */
 
-import '@types/ace';
 import { IJodit, ISourceEditor } from '../../../../types';
 import * as consts from '../../../../constants';
 import { isString, loadNext } from '../../../../modules/helpers';

--- a/src/plugins/source/editor/engines/ace.ts
+++ b/src/plugins/source/editor/engines/ace.ts
@@ -4,6 +4,7 @@
  * Copyright (c) 2013-2020 Valeriy Chupurnov. All rights reserved. https://xdsoft.net
  */
 
+import '@types/ace';
 import { IJodit, ISourceEditor } from '../../../../types';
 import * as consts from '../../../../constants';
 import { isString, loadNext } from '../../../../modules/helpers';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,7 @@
 		"lib": ["es5", "esnext", "dom", "scripthost"]
 	},
 
+	"files": ["node_modules/@types/ace"],
+
 	"exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
## Issues

TypeScript based project build error when import Jodit.

**1) JoditArray.ts(16,4) Type 'any' is not assignable to type 'never'.**

```bash
ERROR in /node_modules/jodit/src/modules/helpers/JoditArray.ts(16,4):
TS2322: Type 'any' is not assignable to type 'never'.
```

**2) Cannot find namespace 'AceAjax' (#358)**

```bash
ERROR in /node_modules/jodit/src/plugins/source/editor/engines/ace.ts(12,45):
TS2503: Cannot find namespace 'AceAjax'.
ERROR in /node_modules/jodit/src/plugins/source/editor/engines/ace.ts(33,36):
TS2503: Cannot find namespace 'AceAjax'.
ERROR in /node_modules/jodit/src/plugins/source/editor/engines/ace.ts(123,13):
TS2503: Cannot find namespace 'AceAjax'.
ERROR in /node_modules/jodit/src/plugins/source/editor/engines/ace.ts(289,9):
TS2503: Cannot find namespace 'AceAjax'.
```


## How to reproduce

TypeScript based project with `tsconfig.json` `noImplicitAny: true`.

```typescript
import 'jodit';
// or only type import as type reference
import { Config } from 'jodit/src/Config';
```


## What I fixed

> **1) JoditArray.ts(16,4) Type 'any' is not assignable to type 'never'.**

Fix type empty array as `any[]`

> **2) Cannot find namespace 'AceAjax' (#358)**

- Fix: `package.json` moved `@types/ace` devDependencies to dependencies.
- Add: `tsconfig.json` `"files": ["node_modules/@types/ace"`].


---

I am not sure it's the correct solution. 😅 
