### PR TITLE
Reduce useless production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
 		"gulp": "^4.0.2",
 		"gulp-imagemin": "^6.2.0",
 		"gulp-less": "^4.0.1",
+		"gulp-typescript": "^5.0.1",
 		"husky": "^1.3.1",
+		"chai": "^4.2.0",
+		"mocha": "^7.0.1"
 		"karma": "^4.4.1",
 		"karma-chai": "^0.1.0",
 		"karma-chrome-launcher": "^2.2.0",
@@ -111,8 +114,5 @@
 	},
 	"dependencies": {
 		"@types/ace": "0.0.42",
-		"chai": "^4.2.0",
-		"gulp-typescript": "^5.0.1",
-		"mocha": "^7.0.1"
 	}
 }


### PR DESCRIPTION
Move test framework `mocha`, assertion library `chai` and gulp plugin `gulp-typescript`  from dependencies to devDependencies

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
