### PR TITLE
Somthing (empty paragraph) before the text paragraph , select all, then click color, should change all text color Issues#475 

### DIFF
--- a/src/plugins/color.ts
+++ b/src/plugins/color.ts
@@ -105,7 +105,7 @@ Config.prototype.controls.brush = {
 		const backgroundTag: HTMLElement = ColorPickerWidget(
 			editor,
 			(value: string) => {
-				if (!currentElement) {
+				if (!currentElement || currentElement===editor.s.current()) {
 					editor.execCommand('background', false, value);
 				} else {
 					currentElement.style.backgroundColor = value;
@@ -122,7 +122,7 @@ Config.prototype.controls.brush = {
 		const colorTab: HTMLElement = ColorPickerWidget(
 			editor,
 			(value: string) => {
-				if (!currentElement) {
+				if (!currentElement || currentElement===editor.s.current()) {
 					editor.execCommand('forecolor', false, value);
 				} else {
 					currentElement.style.color = value;

--- a/test/tests/acceptance/plugins/color.js
+++ b/test/tests/acceptance/plugins/color.js
@@ -62,7 +62,7 @@ describe('Color plugin', function() {
             popup.querySelector('[data-color="#FF0000"]')
 		);
 		
-		// then select red forecolor
+		// then select yellow forecolor
         simulateEvent(
             'mousedown',
             0,

--- a/test/tests/acceptance/plugins/color.js
+++ b/test/tests/acceptance/plugins/color.js
@@ -45,6 +45,35 @@ describe('Color plugin', function() {
 		expect(popup2).is.null;
 	});
 
+	it('somthing (like img or just empty paragraph) before the text paragraph , select all, then click color, should change all text color', function() {
+        const editor = getJodit();
+
+        editor.value = '<p><br></p><p>test</p>';
+
+        clickButton('selectall', editor);
+
+		// select red background
+        clickButton('brush', editor);
+        let popup = getOpenedPopup(editor);
+		expect(window.getComputedStyle(popup).display).equals('block');
+        simulateEvent(
+            'mousedown',
+            0,
+            popup.querySelector('[data-color="#FF0000"]')
+		);
+		
+		// then select red forecolor
+        simulateEvent(
+            'mousedown',
+            0,
+            popup.querySelectorAll('[data-color="#FFFF00"]')[1] // the forecolor color
+		);
+
+        expect(editor.value).include(
+            '<p><span style="background-color: rgb(255, 0, 0); color: rgb(255, 255, 0);">test</span></p>'
+        );
+	});
+
 	describe('Show native color picker', function() {
 		describe('Enable', function() {
 			it('should open color picker with button - native color picker', function() {


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #475 
somthing (like img or just empty paragraph) before the text paragraph , select all, then click color, should change all text color

Maybe it can handle this problem ,please check :)

I've successfully run `npm test` locally
There are new or updated tests validating the change

