### PR TITLE
Updated TEXT_HTML constant in case of IS_IE == true

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -98,7 +98,7 @@ export const IS_IE =
  * @property {string} TEXT_PLAIN='text/plain'  For IE11 it will be 'text'. Need for dataTransfer.setData
  */
 export const TEXT_PLAIN = IS_IE ? 'text' : 'text/plain';
-export const TEXT_HTML = IS_IE ? 'text' : 'text/html';
+export const TEXT_HTML = IS_IE ? 'html' : 'text/html';
 
 export const MARKER_CLASS = 'jodit-selection_marker';
 


### PR DESCRIPTION
This solves error #491 . Before, HTML text in IE11 was treated as plain text because of this

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
