### PR TITLE
Run command insertUnorderedList & insertOrderedList should replace all headings (h1, h2, etc) to ul>li

### DIFF
--- a/src/plugins/ordered-list.ts
+++ b/src/plugins/ordered-list.ts
@@ -110,7 +110,7 @@ export function orderedList(editor: IJodit): void {
 					});
 				}
 
-				if (ul && Dom.isTag(ul.parentNode, 'p')) {
+				if (ul && Dom.isBlock(ul.parentNode)) {
 					const selection: markerInfo[] = editor.s.save();
 
 					Dom.unwrap(ul.parentNode);

--- a/src/plugins/ordered-list.ts
+++ b/src/plugins/ordered-list.ts
@@ -110,7 +110,7 @@ export function orderedList(editor: IJodit): void {
 					});
 				}
 
-				if (ul && Dom.isBlock(ul.parentNode)) {
+				if (ul && Dom.isTag(ul.parentNode, ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'])) {
 					const selection: markerInfo[] = editor.s.save();
 
 					Dom.unwrap(ul.parentNode);

--- a/test/tests/acceptance/plugins/orderedList.js
+++ b/test/tests/acceptance/plugins/orderedList.js
@@ -7,7 +7,7 @@ describe('Test orderedList plugin', function() {
 	describe('Commands', function() {
 		describe('Unordered', function() {
 			describe('insertUnorderedList', function() {
-				it('Run command insertUnorderedList should wrap or replace all block elements to ul>li', function() {
+				it('Run command insertUnorderedList should wrap or replace all paragraphs and headings to ul>li', function() {
 					const editor = getJodit();
 					editor.value = '<h1>test</h1><h2>test</h2><p>test</p>';
 

--- a/test/tests/acceptance/plugins/orderedList.js
+++ b/test/tests/acceptance/plugins/orderedList.js
@@ -7,9 +7,9 @@ describe('Test orderedList plugin', function() {
 	describe('Commands', function() {
 		describe('Unordered', function() {
 			describe('insertUnorderedList', function() {
-				it('Run command insertUnorderedList should wrap or replace all paragraphs to ul>li', function() {
+				it('Run command insertUnorderedList should wrap or replace all block elements to ul>li', function() {
 					const editor = getJodit();
-					editor.value = '<p>test</p><p>test</p><p>test</p>';
+					editor.value = '<h1>test</h1><h2>test</h2><p>test</p>';
 
 					editor.execCommand('selectAll');
 					editor.execCommand('insertUnorderedList');


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `npm test` locally
[x] There are new or updated tests validating the change

-->

Fixes #514
