### PR TITLE
Fix custom button name become empty in getIcon

### DIFF
--- a/src/modules/toolbar/button/button.ts
+++ b/src/modules/toolbar/button/button.ts
@@ -233,8 +233,7 @@ export class ToolbarButton<T extends IViewBased = IViewBased>
 			if (control.iconURL) {
 				state.icon.iconURL = control.iconURL;
 			} else {
-				const name = control.icon || control.name;
-				state.icon.name = Icon.exists(name) ? name : '';
+				state.icon.name = control.icon || control.name;
 			}
 
 			if (!control.iconURL && !state.icon.name) {


### PR DESCRIPTION
Issue: name and clearName are empty in getIcon for custom buttons (including extraButtons)...

Findings: Base on the code, the icon/name should be exists in Icon collection.

Background: In my case, I don't have access to modules.Icon to add custom icons.

Questions: 
 1) is there's a reason why do we need to make it empty if icon/name is not exists in Icon collection?
 2) is it possible to allow the consumer to pass a list of custom icons and merge it to collection using config?
        - e.g. state.icon.name = [...Icon, ...config.extraIcons].includes(name) ? name : '';

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
