### PR TITLE
Fixed Paste as HTML dialog only appearing once

### DIFF
--- a/src/plugins/clipboard/paste/paste.ts
+++ b/src/plugins/clipboard/paste/paste.ts
@@ -171,7 +171,7 @@ export class paste extends Plugin {
 	 */
 	private processHTML(e: PasteEvent, html: string): boolean {
 		if (this.j.o.askBeforePasteHTML) {
-			const cached = this.pasteStack.find(({ html }) => html === html);
+			const cached = this.pasteStack.find((cachedItem) => cachedItem.html === html);
 
 			if (cached) {
 				this.insertByType(


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #589. "Keep as HTML" dialog only appears once due to pasteStack.find() always returning the first cached item.
