### PR TITLE
Fixed spellcheck set to false

### DIFF
--- a/src/jodit.ts
+++ b/src/jodit.ts
@@ -1434,6 +1434,8 @@ export class Jodit extends ViewWithToolbar implements IJodit {
 
 		if (this.o.spellcheck) {
 			this.editor.setAttribute('spellcheck', 'true');
+		} else {
+			this.editor.setAttribute('spellcheck', 'false');
 		}
 
 		// direction


### PR DESCRIPTION
When spellcheck is not added the default value is browser defined, in most of them the default value is true.

Fixes #650 
