### PR TITLE
Fixed license mispelling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
       "homepage": "http://xdsoft.net/contacts.html"
     }
   ],
-  "license": "GPL-2.0-or-later",
+  "license": "MIT",
   "keywords": [
     "wysiwyg",
     "jquery",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "xdan/jodit",
     "description": "Awesome WYSIWYG editor and FileBrowser",
     "type": "library",
-    "license": "GPL-2.0-or-later",
+    "license": "MIT",
     "authors": [
         {
             "name": "Chupurnov Valeriy",


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[X ] Code is up-to-date with the `master` branch
[X] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->
Jodit is under MIT license according of home page and repo. I Fixed the license mispelling in bower.json and composer.json
