### PR TITLE
fix removal of attributes width and height when editing images

### DIFF
--- a/src/plugins/image/image-properties/image-properties.ts
+++ b/src/plugins/image/image-properties/image-properties.ts
@@ -643,17 +643,20 @@ export class imageProperties extends Plugin {
 			imageWidth.value !== image.offsetWidth.toString() ||
 			imageHeight.value !== image.offsetHeight.toString()
 		) {
+			const updatedtWidth = trim(imageWidth.value)
+				? normalSizeToString(imageWidth.value)
+				: null;
+			const updatedHeight = trim(imageHeight.value)
+				? normalSizeToString(imageHeight.value)
+				: null;
+
 			css(image, {
-				width: trim(imageWidth.value)
-					? normalSizeToString(imageWidth.value)
-					: null,
-				height: trim(imageHeight.value)
-					? normalSizeToString(imageHeight.value)
-					: null
+				width: updatedtWidth,
+				height: updatedHeight
 			});
 
-			attr(image, 'width', null);
-			attr(image, 'height', null);
+			attr(image, 'width', attr(image, 'width') ? updatedtWidth : null);
+			attr(image, 'height', attr(image, 'height') ? updatedHeight : null);
 		}
 
 		const margins = [marginTop, marginRight, marginBottom, marginLeft];


### PR DESCRIPTION
Now you force the width and height attributes to zero, but sometimes I need them (for example, to send emails in Microsoft Outlook). I propose to reset them only if these attributes were not present before editing. And if there were, then continue to updating them. Thanks.


Thank you for submitting a pull request!

Here's a checklist you might find useful.
[no, it is my own idea] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[yes] Code is up-to-date with the `master` branch
[no, tests broke on master, not only in my branch] You've successfully run `npm test` locally
[no] There are new or updated tests validating the change


Fixes #
