### PR TITLE
fix: Proxy blur event to parent triggered on the ACE editor

### DIFF
--- a/src/plugins/source/editor/engines/ace.ts
+++ b/src/plugins/source/editor/engines/ace.ts
@@ -22,6 +22,10 @@ export class AceEditor
 	/**
 	 * Proxy Method
 	 */
+	private proxyOnBlur = (e: MouseEvent) => {
+		this.j.e.fire('blur', e);
+	};
+
 	private proxyOnFocus = (e: MouseEvent) => {
 		this.j.e.fire('focus', e);
 	};
@@ -133,6 +137,7 @@ export class AceEditor
 			this.instance.on('change', this.toWYSIWYG as any);
 			this.instance.on('focus', this.proxyOnFocus);
 			this.instance.on('mousedown', this.proxyOnMouseDown);
+			this.instance.on('blur', this.proxyOnBlur);
 
 			if (editor.getRealMode() !== constants.MODE_WYSIWYG) {
 				this.setValue(this.getValue());


### PR DESCRIPTION
[yes, I opened the issue #750 ] There is an associated issue that is labelled 'Bug' or 'help wanted' or is in the Community milestone
[yes] Code is up-to-date with the `master` branch
[yes] You've successfully run `npm test` locally
[no] There are new or updated tests validating the change

Fixes #
As the issue describes, the `blur` event was not caught on the ACE editor. The change is pretty simple.