### PR TITLE
Allow propper keyboard navigation in the toolbar

### DIFF
--- a/src/core/ui/button/button/button.less
+++ b/src/core/ui/button/button/button.less
@@ -33,7 +33,7 @@
 .jodit-ui-button-interaction() {
 	cursor: pointer;
 
-	&:hover:not([disabled]) {
+	&:hover:not([disabled]), &:focus-visible:not([disabled]) {
 		background-color: var(--color-button-background-hover);
 		opacity: 1;
 		outline: 0;

--- a/src/core/ui/popup/popup.ts
+++ b/src/core/ui/popup/popup.ts
@@ -113,7 +113,11 @@ export class Popup extends UIElement implements IPopup {
 	/**
 	 * Open popup near with some bound
 	 */
-	open(getBound: getBoundFunc, keepPosition: boolean = false): this {
+	open(
+		getBound: getBoundFunc,
+		keepPosition: boolean = false,
+		parentContainer?: HTMLElement
+	): this {
 		markOwner(this.jodit, this.container);
 
 		this.calculateZIndex();
@@ -125,10 +129,14 @@ export class Popup extends UIElement implements IPopup {
 			? getBound
 			: this.getKeepBound(getBound);
 
-		const parentContainer = getContainer(this.jodit, Popup);
-
-		if (parentContainer !== this.container.parentElement) {
+		if (parentContainer) {
 			parentContainer.appendChild(this.container);
+		} else {
+			const popupContainer = getContainer(this.jodit, Popup);
+
+			if (parentContainer !== this.container.parentElement) {
+				popupContainer.appendChild(this.container);
+			}
 		}
 
 		this.updatePosition();

--- a/src/modules/toolbar/button/button.ts
+++ b/src/modules/toolbar/button/button.ts
@@ -368,7 +368,13 @@ export class ToolbarButton<T extends IViewBased = IViewBased>
 						.setContent(
 							isString(elm) ? this.j.c.fromHTML(elm) : elm
 						)
-						.open(() => position(this.container));
+						.open(
+							() => position(this.container),
+							false,
+							this.j.o.allowTabNavigation
+								? this.container
+								: undefined
+						);
 				}
 			}
 
@@ -450,7 +456,11 @@ export class ToolbarButton<T extends IViewBased = IViewBased>
 			this.target
 		);
 
-		menu.setContent(toolbar.container).open(() => position(this.container));
+		menu.setContent(toolbar.container).open(
+			() => position(this.container),
+			false,
+			this.j.o.allowTabNavigation ? this.container : undefined
+		);
 
 		this.state.activated = true;
 	}

--- a/src/types/popup.d.ts
+++ b/src/types/popup.d.ts
@@ -24,7 +24,11 @@ export interface IPopup extends IUIElement, IDestructible {
 	strategy: PopupStrategy;
 	viewBound: () => IBound;
 
-	open(getBound: () => IBound, keepPosition?: boolean): this;
+	open(
+		getBound: () => IBound,
+		keepPosition?: boolean,
+		parentContainer?: HTMLElement
+	): this;
 
 	setContent(content: IUIElement | HTMLElement | string): this;
 	updatePosition(): this;

--- a/test/tests/acceptance/editorTest.js
+++ b/test/tests/acceptance/editorTest.js
@@ -389,6 +389,29 @@ describe('Jodit Editor Tests', function () {
 				expect(popup.parentNode.parentNode === root).is.true;
 			});
 
+			it('Should create toolbar button popups elements outside the shadow root for keyboard tab navigation ', function () {
+				const app = appendTestDiv();
+				app.attachShadow({ mode: 'open' });
+				const root = app.shadowRoot;
+
+				root.innerHTML = '<div id="edit"></div>';
+
+				const editor = getJodit(
+					{
+						globalFullSize: false,
+						shadowRoot: root,
+						allowTabNavigation: true
+					},
+					root.getElementById('edit')
+				);
+
+				clickButton('brush', editor);
+
+				const popup = getOpenedPopup(editor);
+
+				expect(popup.parentNode.parentNode !== root).is.true;
+			});
+
 			describe('Select element inside', function () {
 				it('Should use Selection from shadow root', function () {
 					const app = appendTestDiv();


### PR DESCRIPTION
This PR updates the toolbar button and the popup to allow a proper
keyboard tab navigation.

The problem with the tab navigation is that the editor uses a shadow
root at the end of the HTML to put popups, this change put the popup
inside the span that contains each toolbar button if the config
allowTabNavigation is active.

Fixes https://github.com/xdan/jodit/issues/810

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->


