### PR TITLE
This commit makes the source editor blur on esc

### DIFF
--- a/src/jodit.ts
+++ b/src/jodit.ts
@@ -723,7 +723,9 @@ export class Jodit extends ViewWithToolbar implements IJodit {
 		this.e
 			.off(shortcuts)
 			.on(shortcuts, (type: string, stop: { shouldStop: boolean }) => {
-				stop.shouldStop = shouldStop ?? true;
+				if (stop) {
+					stop.shouldStop = shouldStop ?? true;
+				}
 				return this.execCommand(commandName); // because need `beforeCommand`
 			});
 	}

--- a/src/plugins/source/editor/engines/ace.ts
+++ b/src/plugins/source/editor/engines/ace.ts
@@ -231,6 +231,10 @@ export class AceEditor
 		this.instance.focus();
 	}
 
+	blur(): void {
+		this.instance.blur();
+	}
+
 	getSelectionStart(): number {
 		const range = this.instance.selection.getRange();
 

--- a/src/plugins/source/editor/engines/area.ts
+++ b/src/plugins/source/editor/engines/area.ts
@@ -98,6 +98,10 @@ export class TextAreaEditor
 		this.instance.focus();
 	}
 
+	blur(): void {
+		this.instance.blur();
+	}
+
 	setPlaceHolder(title: string): void {
 		this.instance.setAttribute('placeholder', title);
 	}

--- a/src/plugins/source/source.ts
+++ b/src/plugins/source/source.ts
@@ -307,6 +307,19 @@ export class source extends Plugin {
 			this.fromWYSIWYG
 		);
 
+		editor.registerCommand(
+			'escapeSourceEditor',
+			{
+				exec: () => {
+					this.sourceEditor?.blur();
+				},
+				hotkeys: ['esc']
+			},
+			{
+				stopPropagation: false
+			}
+		);
+
 		this.onReadonlyReact();
 
 		editor.e

--- a/src/types/source.d.ts
+++ b/src/types/source.d.ts
@@ -21,6 +21,7 @@ export interface ISourceEditor extends IDestructible, IInitable {
 	setPlaceHolder(title: string): void;
 
 	focus(): void;
+	blur(): void;
 
 	setReadOnly(isReadOnly: boolean): void;
 


### PR DESCRIPTION
This PR makes the source editor blur when the esc key is pressed,
this change is intended to solve a keyboard trap (we can't leave the
source editor using the keyboard).

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes https://github.com/xdan/jodit/issues/817
