### PR TITLE
Img height width attr

### DIFF
--- a/src/core/helpers/utils/attr.ts
+++ b/src/core/helpers/utils/attr.ts
@@ -88,8 +88,15 @@ export function attr(
 		if (value == null) {
 			elm.hasAttribute(key) && elm.removeAttribute(key);
 		} else {
-			elm.setAttribute(key, value.toString());
-			return value.toString();
+			let replaceValue = value.toString();
+			if (
+				elm.nodeName === 'IMG' &&
+				(key === 'width' || key === 'height')
+			) {
+				replaceValue = replaceValue.replace('px', '');
+			}
+			elm.setAttribute(key, replaceValue);
+			return replaceValue;
 		}
 	}
 

--- a/src/modules/file-browser/file-browser.test.js
+++ b/src/modules/file-browser/file-browser.test.js
@@ -845,7 +845,7 @@ function getFirstItem(fb, index = 0, file = false) {
 					);
 
 					expect(editor.value).equals(
-						'<p>Some text</p><p>Another<img src="https://xdsoft.net/jodit/files/ibanez-s520-443140.jpg" width="300px"> text</p><p>Another some text</p>'
+						'<p>Some text</p><p>Another<img src="https://xdsoft.net/jodit/files/ibanez-s520-443140.jpg" width="300"> text</p><p>Another some text</p>'
 					);
 
 					filebrowser.destruct();

--- a/src/modules/uploader/uploader.test.js
+++ b/src/modules/uploader/uploader.test.js
@@ -25,7 +25,7 @@ describe('Test uploader module', function () {
 								expect(sortAttributes(editor.value)).equals(
 									'<p>test<img src="' +
 										file.dataURI +
-										'" width="300px"></p>'
+										'" width="300"></p>'
 								);
 								done();
 							}

--- a/test/tests/acceptance/image.test.js
+++ b/test/tests/acceptance/image.test.js
@@ -999,7 +999,7 @@ describe('Test image', function () {
 							clickButton('ok', dialog);
 
 							expect(sortAttributes(editor.value)).equals(
-								'<p><img height="1900px" src="tests/artio.jpg" style="height:1900px;width:200px" width="200px"></p>'
+								'<p><img height="1900px" src="tests/artio.jpg" style="height:1900px;width:200px" width="200"></p>'
 							);
 
 							done();

--- a/test/tests/acceptance/image.test.js
+++ b/test/tests/acceptance/image.test.js
@@ -999,7 +999,7 @@ describe('Test image', function () {
 							clickButton('ok', dialog);
 
 							expect(sortAttributes(editor.value)).equals(
-								'<p><img height="1900px" src="tests/artio.jpg" style="height:1900px;width:200px" width="200"></p>'
+								'<p><img height="1900" src="tests/artio.jpg" style="height:1900px;width:200px" width="200"></p>'
 							);
 
 							done();

--- a/test/tests/acceptance/image.test.js
+++ b/test/tests/acceptance/image.test.js
@@ -855,7 +855,7 @@ describe('Test image', function () {
 							clickButton('ok', dialog);
 
 							expect(sortAttributes(editor.value)).equals(
-								'<p><img src="tests/artio.jpg" style="height:200px;width:356px" width="356px"></p>'
+								'<p><img src="tests/artio.jpg" style="height:200px;width:356px" width="356"></p>'
 							);
 
 							done();


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `main` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #963 

Checks for img tag type and if key attribute is a width or height type, then it filters out any 'px' within string to follow recommended practice of width/height attribute outside of style/css properties to not have unit string in it as it is defaulted to being a px unit.

Expected behavior:
Width/Height are already in pixels so it should be a numeric string value. For apps powered with Outlook, the pixels in the attribute create conflict.

https://www.w3schools.com/tags/att_width.asp#:~:text=The%20width%20attribute%20specifies%20the,type%3D%22image%22%3E%20.
https://stackoverflow.com/questions/20989897/image-style-height-and-width-not-taken-in-outlook-mails

Actual behavior:
Doesn't ensure numeric string value for height and width attributes.
