### PR TITLE
fix: makefile excludePlugins no longer ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ uglify ?= true
 browsers ?= FirefoxHeadless
 includeLanguages ?= ''
 excludeLanguages ?= ''
+includePlugins ?= ''
+excludePlugins ?= ''
 singleRun ?= true
 isTest ?= false
 debug ?= false
@@ -45,6 +47,8 @@ start:
 		--env uglify=$(uglify) \
 		--env includeLanguages=$(includeLanguages) \
 		--env excludeLanguages=$(excludeLanguages) \
+		--env includePlugins=$(includePlugins) \
+		--env excludePlugins=$(excludePlugins) \
 		--env isTest=$(isTest) \
 		--env fat=$(fat)
 
@@ -57,6 +61,8 @@ build:
 		--env isTest=$(isTest) \
 		--env includeLanguages=$(includeLanguages) \
 		--env excludeLanguages=$(excludeLanguages) \
+		--env includePlugins=$(includePlugins) \
+		--env excludePlugins=$(excludePlugins) \
 		--env outputFolder=$(outputFolder) \
 		--env fat=$(fat) \
 		--env generateTypes=$(generateTypes)

--- a/tools/external/exclude-plugins.ts
+++ b/tools/external/exclude-plugins.ts
@@ -5,8 +5,29 @@
  */
 
 import type { Variables } from '../variables';
+import * as fs from 'fs';
+import * as path from 'path';
 
-export default ({ excludePlugins }: Variables): { [key in string]: string } => {
+export default ({
+	excludePlugins,
+	includePlugins,
+	superDirname
+}: Variables): { [key in string]: string } => {
+	if (
+		includePlugins &&
+		Array.isArray(includePlugins) &&
+		includePlugins.filter(Boolean).length
+	) {
+		console.info('Include plugins:', includePlugins);
+
+		excludePlugins = fs
+			.readdirSync(path.resolve(superDirname, './src/plugins'))
+			.filter(
+				(file: string) =>
+					!file.match(/\.\w+$/) && !includePlugins.includes(file)
+			);
+	}
+
 	if (
 		excludePlugins &&
 		Array.isArray(excludePlugins) &&

--- a/tools/variables.ts
+++ b/tools/variables.ts
@@ -23,6 +23,7 @@ export type Argv = {
 	stat?: boolean;
 	exclude?: string;
 	excludePlugins?: string;
+	includePlugins?: string;
 	excludeLanguages?: string;
 	includeLanguages?: string;
 	es?: ES_TARGET;
@@ -55,6 +56,7 @@ export type Variables = {
 	excludeLanguages: string[];
 	includeLanguages: string[];
 	excludePlugins: string[];
+	includePlugins: string[];
 	progressFunction:
 		| ((percentage: number, msg: string, ...args: string[]) => void)
 		| false;
@@ -94,6 +96,7 @@ export const variables = (argv: Argv, dir: string): Variables => {
 	const exclude = (argv.exclude || '').split(/[,\s;]/);
 
 	const excludePlugins = (argv.excludePlugins || '').split(/[,\s;]/);
+	const includePlugins = (argv.includePlugins || '').split(/[,\s;]/);
 	const excludeLanguages = (argv.excludeLanguages || '').split(/[,\s;]/);
 	const includeLanguages = (argv.includeLanguages || '').split(/[,\s;]/);
 
@@ -134,6 +137,7 @@ export const variables = (argv: Argv, dir: string): Variables => {
 		excludeLanguages,
 		includeLanguages,
 		excludePlugins,
+		includePlugins,
 		progressFunction:
 			typeof argv.progressFunction === 'function'
 				? argv.progressFunction


### PR DESCRIPTION
fix: makefile excludePlugins no longer ignored
feat: add includePlugins to make for users with a shortlist of plugins

Fixes #986 
