### PR TITLE
fix import

### DIFF
--- a/src/plugins/line-height/langs/index.ts
+++ b/src/plugins/line-height/langs/index.ts
@@ -46,4 +46,4 @@ export {
 	tr,
 	zh_cn,
 	zh_tw
-};
+} from './';


### PR DESCRIPTION
this fix enable some framework (like angular) to read correctly lang path. Without this reference the usage of this plugin cause missing reference

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[X] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[Y] Code is up-to-date with the `main` branch
[Y] You've successfully run `npm test` locally
[X] There are new or updated tests validating the change

-->

Fixes #
