### PR TITLE
Fix Cannot access ' ' before initialization on build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,16 +10,16 @@
  * @module jodit
  */
 
+import { Jodit as DefaultJodit } from './jodit';
 import { isFunction, isString } from 'jodit/core/helpers/checker';
-
-import 'jodit/plugins/index';
 
 import * as constants from './core/constants';
 import * as decorators from './core/decorators';
 import * as Modules from './modules/';
 import * as Icons from './styles/icons/';
-import { Jodit as DefaultJodit } from './jodit';
 import Languages from './languages';
+
+import 'jodit/plugins/index';
 
 import './styles/index.less';
 import './styles/themes/dark.less';

--- a/tools/utils/resolve-alias-imports.ts
+++ b/tools/utils/resolve-alias-imports.ts
@@ -70,7 +70,6 @@ const allowPluginsInESM = new Set(
 		'delete',
 		'dtd',
 		'enter',
-		'enter',
 		'font',
 		'format-block',
 		'hotkeys',


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `main` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
Looks like this reordering makes ESM imports work both on dev and on prod (with bundling, minification and etc). The major one is to pull Plugins down and imports them last.