### PR TITLE
feat: add config in other builds than esm

### DIFF
--- a/tools/webpack.config.ts
+++ b/tools/webpack.config.ts
@@ -62,7 +62,7 @@ export default (
 		devtool: debug ? 'inline-source-map' : false,
 
 		entry: {
-			jodit: ['./src/index'],
+			jodit: ['./src/index', './src/config'],
 			...(!fat ? pluginsEntries : {})
 		},
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
https://github.com/xdan/jodit/issues/1172

[x] Code is up-to-date with the `main` branch
[x] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change
Not applicable
-->

Fixes https://github.com/xdan/jodit/issues/1172

Add Config entry so projects using `jodit-react` can access the config module when creating custom plugins
