### PR TITLE
Don't remove nodes with visible whitespace

### DIFF
--- a/src/plugins/clean-html/helpers/visitor/filters/try-remove-node.ts
+++ b/src/plugins/clean-html/helpers/visitor/filters/try-remove-node.ts
@@ -11,7 +11,7 @@
 import type { IDictionary, IJodit, Nullable } from 'jodit/types';
 import { IS_INLINE } from 'jodit/core/constants';
 import { Dom } from 'jodit/core/dom/dom';
-import { trim } from 'jodit/core/helpers/string/trim';
+import { trimInv } from 'jodit/core/helpers/string/trim';
 
 /**
  * @private
@@ -68,7 +68,7 @@ function isRemovableNode(
 		Dom.isElement(node) &&
 		node.nodeName.match(IS_INLINE) != null &&
 		!Dom.isTemporary(node) &&
-		trim((node as Element).innerHTML).length === 0 &&
+		trimInv((node as Element).innerHTML).length === 0 &&
 		(current == null || !Dom.isOrContains(node, current))
 	);
 }


### PR DESCRIPTION
Some word processors produce HTML that looks like this:
`<p>Hi<em> </em>hello<p>`
When you copy and paste this into Jodit, Jodit removes inline nodes with only whitespace inside, like the above `<em>`. The pasted text becomes this after it is cleaned:
<img width="224" height="62" alt="Screenshot from 2025-08-16 17-17-24" src="https://github.com/user-attachments/assets/2ce8ad5f-5be6-4db5-87c9-72b81170bd34" />

Instead of this, which is how the text appears in the word processor:
<img width="224" height="62" alt="Screenshot from 2025-08-16 17-16-11" src="https://github.com/user-attachments/assets/8fbfb873-9992-4eb3-90ae-cbcba157610f" />

This fixes the issue by only removing nodes with *invisible* whitespace.