### PR TITLE
fix: handle image decoding errors in readSizes function

### DIFF
--- a/src/plugins/image-properties/image-properties.ts
+++ b/src/plugins/image-properties/image-properties.ts
@@ -265,7 +265,11 @@ export class imageProperties extends Plugin {
 
 		try {
 			this.__lock();
-			await image.decode();
+			try {
+				await image.decode();
+			} catch (e: unknown) {
+				console.error(e);
+			}
 			if (this.state.sizeIsLocked && isNumeric(values.imageWidth)) {
 				const w = parseFloat(values.imageWidth.toString());
 				values.imageHeight = Math.round(w / this.state.ratio);

--- a/src/plugins/image-properties/readers/size.ts
+++ b/src/plugins/image-properties/readers/size.ts
@@ -21,7 +21,11 @@ export async function readSizes(
 	values: EditValues,
 	state: ImagePropertiesState
 ): Promise<void> {
-	await image.decode();
+	try {
+		await image.decode();
+	} catch (e: unknown) {
+		console.error(e);
+	}
 
 	const width = css(image, 'width', true) || attr(image, 'width') || false;
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[x] Code is up-to-date with the `main` branch
[x] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #1305

Fallback to the styles and attributes if image cannot be decoded