### PR TITLE
Fix image properties styles for legacy class names

### DIFF
--- a/src/plugins/image-properties/ui/ui-image-form.less
+++ b/src/plugins/image-properties/ui/ui-image-form.less
@@ -25,7 +25,8 @@
 		padding: var(--padding-default);
 	}
 
-	&__imageView {
+	&__imageView,
+	.jodit-properties_image_view {
 		display: flex;
 		height: var(--width-default);
 		align-items: center;
@@ -40,7 +41,8 @@
 		}
 	}
 
-	&__imageSizes.jodit-form__group {
+	&__imageSizes.jodit-form__group,
+	.jodit-properties_image_sizes.jodit-form__group {
 		min-width: auto;
 		flex-direction: row;
 		align-items: center;
@@ -68,6 +70,10 @@
 		&__imageView {
 			background-color: var(--dark-background-color);
 		}
+	}
+
+	.jodit-properties_image_view {
+		background-color: var(--dark-background-color);
 	}
 }
 


### PR DESCRIPTION
## Description
- Ensure image properties styling applies when legacy class names are rendered (`jodit-properties_image_view` / `jodit-properties_image_sizes`).

## Related Issue
Fixes #1327

## Checklist
- [x] There is an associated issue labeled `bug` or `enhancement`
- [ ] Code is up-to-date with the `main` branch
- [ ] `npm test` passes locally
- [ ] New or updated tests validate the change
