### PR TITLE
Fix resize handle not showing when status counters are disabled

### DIFF
--- a/src/plugins/resize-handler/resize-handler.ts
+++ b/src/plugins/resize-handler/resize-handler.ts
@@ -37,6 +37,7 @@ export class resizeHandler extends Plugin {
 			(allowResizeX || allowResizeY)
 		) {
 			editor.statusbar.setMod('resize-handle', true);
+			editor.statusbar.show();
 
 			editor.e
 				.on('toggleFullSize.resizeHandler', () => {

--- a/src/plugins/size/size.test.js
+++ b/src/plugins/size/size.test.js
@@ -288,6 +288,24 @@
 
 		describe('Disable auto-height', function () {
 			describe('Resize handle', function () {
+				it('Should show resize handle when counters are hidden', function () {
+					const editor = getJodit({
+						height: 300,
+						allowResizeX: true,
+						allowResizeY: true,
+						showCharsCounter: false,
+						showWordsCounter: false,
+						showXPathInStatusbar: false
+					});
+
+					const handle = editor.container.querySelector(
+						'.jodit-editor__resize'
+					);
+
+					expect(handle).is.not.null;
+					expect(editor.statusbar.container.offsetHeight).is.above(0);
+				});
+
 				it('Should resize editor', function () {
 					const box = getBox();
 					box.style.width = 'auto';


### PR DESCRIPTION
## Description

- keep the resize handle visible even when status-bar counters/xpath are disabled
- explicitly show the status bar when resize is enabled so the handle has visible space
- add a regression test that reproduces issue #1335 config (`showCharsCounter/showWordsCounter/showXPathInStatusbar = false`)

## Related Issue

Fixes #1335

## Checklist

- [x] There is an associated issue labeled `bug` or `enhancement`
- [x] Code is up-to-date with the `main` branch
- [ ] `npm test` passes locally
- [x] New or updated tests validate the change
