### PR TITLE
Security: Unsafe link opening can allow `javascript:` URL execution

### DIFF
--- a/src/plugins/inline-popup/config/items/a.ts
+++ b/src/plugins/inline-popup/config/items/a.ts
@@ -11,6 +11,10 @@
 import type { IControlType, IJodit } from 'jodit/types';
 import { attr } from 'jodit/core/helpers/utils/attr';
 
+const isSafeHref = (href: string): boolean =>
+	/^(https?:|mailto:|tel:)/i.test(href.trim()) &&
+	!/^(javascript:|data:|vbscript:)/i.test(href.trim());
+
 export default [
 	{
 		name: 'eye',
@@ -18,7 +22,7 @@ export default [
 		exec: (editor: IJodit, current): void => {
 			const href = attr(current as HTMLElement, 'href');
 
-			if (current && href) {
+			if (current && href && isSafeHref(href)) {
 				editor.ow.open(href);
 			}
 		}

--- a/src/plugins/speech-recognize/helpers/exec-spell-command.ts
+++ b/src/plugins/speech-recognize/helpers/exec-spell-command.ts
@@ -12,5 +12,14 @@ import type { IJodit } from 'jodit/types';
 
 export function execSpellCommand(jodit: IJodit, commandSentence: string): void {
 	const [command, value] = commandSentence.split('::');
+
+	if (
+		command.toLowerCase() === 'open' &&
+		value &&
+		/^(javascript:|data:|vbscript:)/i.test(value.trim())
+	) {
+		return;
+	}
+
 	jodit.execCommand(command, null, value);
 }


### PR DESCRIPTION
## Problem

The inline link popup reads `href` from the current element and calls `editor.ow.open(href)` directly. Without protocol validation, attacker-controlled links such as `javascript:...` or other dangerous schemes may execute script in the page context when users click 'Open link'.

**Severity**: `high`
**File**: `src/plugins/inline-popup/config/items/a.ts`

## Solution

Validate and sanitize `href` before opening. Allow only safe schemes (`http`, `https`, optionally `mailto`, `tel`) and explicitly block `javascript:`, `data:`, and other executable schemes.

## Changes

- `src/plugins/inline-popup/config/items/a.ts` (modified)
- `src/plugins/speech-recognize/helpers/exec-spell-command.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
