### PR TITLE
Fix keyboard access for toolbar dropdown triggers

### DIFF
--- a/src/core/ui/accessibility.test.js
+++ b/src/core/ui/accessibility.test.js
@@ -120,6 +120,42 @@ describe('Accessibility', () => {
 			expect(trigger.getAttribute('aria-expanded')).equals('false');
 		});
 
+		it('should be keyboard-accessible when tab navigation is enabled', () => {
+			const editor = getJodit({
+				allowTabNavigation: true,
+				toolbarAdaptive: false,
+				buttons: ['ol', 'ul', 'brush']
+			});
+
+			['ol', 'ul', 'brush'].forEach(name => {
+				const trigger = editor.toolbar.container.querySelector(
+					`[data-ref="${name}"] .jodit-toolbar-button__trigger`
+				);
+
+				expect(trigger.getAttribute('tabindex')).equals('0');
+			});
+
+			const orderedListTrigger = editor.toolbar.container.querySelector(
+				'[data-ref="ol"] .jodit-toolbar-button__trigger'
+			);
+
+			simulateEvent('keydown', Jodit.KEY_ENTER, orderedListTrigger);
+
+			expect(getOpenedPopup(editor)).is.not.null;
+			expect(orderedListTrigger.getAttribute('aria-expanded')).equals(
+				'true'
+			);
+
+			const colorTrigger = editor.toolbar.container.querySelector(
+				'[data-ref="brush"] .jodit-toolbar-button__trigger'
+			);
+
+			simulateEvent('keydown', ' ', colorTrigger);
+
+			expect(getOpenedPopup(editor)).is.not.null;
+			expect(colorTrigger.getAttribute('aria-expanded')).equals('true');
+		});
+
 		it('should set aria-expanded="true" when popup is opened', () => {
 			const editor = getJodit({
 				toolbarAdaptive: false,

--- a/src/modules/toolbar/button/button.ts
+++ b/src/modules/toolbar/button/button.ts
@@ -23,6 +23,7 @@ import type {
 	Nullable
 } from 'jodit/types';
 import { STATUSES } from 'jodit/core/component/statuses';
+import { KEY_ENTER, KEY_SPACE } from 'jodit/core/constants';
 import { autobind } from 'jodit/core/decorators/autobind/autobind';
 import { cacheHTML } from 'jodit/core/decorators/cache/cache';
 import {
@@ -170,6 +171,7 @@ export class ToolbarButton<T extends IViewBased = IViewBased>
 
 	protected override onChangeTabIndex(): void {
 		attr(this.button, 'tabindex', this.state.tabIndex);
+		attr(this.trigger, 'tabindex', this.state.tabIndex);
 	}
 
 	@cacheHTML
@@ -400,6 +402,19 @@ export class ToolbarButton<T extends IViewBased = IViewBased>
 				popup.container
 			);
 		}
+	}
+
+	@watch('trigger:keydown')
+	protected onTriggerKeyDown(e: KeyboardEvent): void {
+		if (
+			this.state.disabled ||
+			![KEY_ENTER, KEY_SPACE, ' '].includes(e.key)
+		) {
+			return;
+		}
+
+		e.preventDefault();
+		this.trigger.click();
 	}
 
 	private openedPopup: Nullable<IPopup> = null;


### PR DESCRIPTION
## Description

Make split-button dropdown triggers participate in tab navigation and activate through Enter or Space. This keeps the existing click path as the single popup-opening implementation while making the trigger itself operable as its `role="button"` promises.

The regression test covers the ordered-list, unordered-list, and color dropdown triggers reported in the issue.

## Related Issue

Fixes #1419

## Validation

- `make test es=es2021 uglify=false browsers=chrome_headless` — 2145 passed, 1 skipped
- `make lint` — passed (4 existing warnings, 0 errors)

## Checklist

- [x] There is an associated issue labeled `bug` or `enhancement`
- [x] Code is up-to-date with the `main` branch
- [x] `npm test` passes locally
- [x] New or updated tests validate the change