### PR TITLE
fix: make table-size picker keyboard navigable

### DIFF
--- a/src/plugins/table/config.ts
+++ b/src/plugins/table/config.ts
@@ -9,6 +9,14 @@
  */
 
 import type { IControlType, IDictionary, IJodit } from 'jodit/types';
+import {
+	KEY_DOWN,
+	KEY_ENTER,
+	KEY_ESC,
+	KEY_LEFT,
+	KEY_RIGHT,
+	KEY_UP
+} from 'jodit/core/constants';
 import { Dom } from 'jodit/core/dom';
 import { $$, css, scrollIntoViewIfNeeded } from 'jodit/core/helpers';
 import { attr } from 'jodit/core/helpers/utils';
@@ -102,27 +110,31 @@ Config.prototype.controls.table = {
 
 		const cnt = default_rows_count * default_cols_count;
 
+		attr(blocksContainer, {
+			role: 'grid',
+			ariaLabel: 'Table size',
+			ariaRowcount: default_rows_count,
+			ariaColcount: default_cols_count
+		});
+
 		for (let i = 0; i < cnt; i += 1) {
 			if (!cells[i]) {
+				const row = Math.floor(i / default_cols_count) + 1,
+					col = (i % default_cols_count) + 1;
+
 				cells.push(
 					editor.c.element('span', {
-						dataIndex: i
+						dataIndex: i,
+						role: 'gridcell',
+						tabindex: i === 0 ? 0 : -1,
+						ariaLabel: `${row} by ${col}`
 					})
 				);
 			}
 		}
 
-		const mouseenter = (e: MouseEvent, index?: number): void => {
-			const dv = e.target;
-
-			if (!Dom.isTag(dv, 'span')) {
-				return;
-			}
-
-			const k =
-				index === undefined || isNaN(index)
-					? parseInt(attr(dv, '-index') || '0', 10)
-					: index || 0;
+		const highlightCell = (cell: HTMLElement): void => {
+			const k = parseInt(attr(cell, '-index') || '0', 10);
 
 			const rows_count = Math.ceil((k + 1) / default_cols_count),
 				cols_count = (k % default_cols_count) + 1;
@@ -142,118 +154,177 @@ Config.prototype.controls.table = {
 			rows.textContent = rows_count.toString();
 		};
 
+		const insertTable = (cell: HTMLElement): void => {
+			const k = parseInt(attr(cell, '-index') || '0', 10);
+
+			const rows_count = Math.ceil((k + 1) / default_cols_count),
+				cols_count = (k % default_cols_count) + 1;
+
+			const crt = editor.createInside,
+				tbody = crt.element('tbody'),
+				table = crt.element('table');
+
+			table.appendChild(tbody);
+
+			let first_td: HTMLTableCellElement | null = null,
+				tr: HTMLTableRowElement,
+				td: HTMLTableCellElement;
+
+			for (let i = 1; i <= rows_count; i += 1) {
+				tr = crt.element('tr');
+
+				for (let j = 1; j <= cols_count; j += 1) {
+					td = crt.element('td');
+
+					if (!first_td) {
+						first_td = td;
+					}
+
+					css(td, 'width', (100 / cols_count).toFixed(4) + '%');
+
+					td.appendChild(crt.element('br'));
+					tr.appendChild(crt.text('\n'));
+					tr.appendChild(crt.text('\t'));
+					tr.appendChild(td);
+				}
+
+				tbody.appendChild(crt.text('\n'));
+				tbody.appendChild(tr);
+			}
+
+			$$('input[type=checkbox]:checked', options).forEach(
+				(input: HTMLElement) => {
+					(input as HTMLInputElement).value
+						.split(/[\s]+/)
+						.forEach((className: string) => {
+							table.classList.add(className);
+						});
+				}
+			);
+
+			editor.s.restore();
+			editor.s.removeMarkers();
+			editor.editor.normalize();
+			editor.history.snapshot.restore(snapshot);
+
+			const block = Dom.furthest(
+				editor.s.current(),
+				Dom.isBlock,
+				editor.editor
+			);
+
+			if (block && Dom.isEmpty(block)) {
+				Dom.replace(block, table, undefined, false, true);
+			} else {
+				if (block) {
+					const fake = crt.text('\n');
+					if (!editor.o.table.splitBlockOnInsertTable) {
+						Dom.after(block, fake);
+						Dom.after(fake, table);
+					} else {
+						const range = editor.s.range;
+						range.collapse(false);
+						range.insertNode(fake);
+						range.collapse(false);
+						editor.s.selectRange(range);
+
+						const firstPart = editor.s.splitSelection(block, fake);
+
+						if (firstPart) {
+							Dom.after(firstPart, table);
+						} else {
+							Dom.after(block, table);
+						}
+					}
+				} else {
+					editor.s.insertNode(table, false);
+				}
+			}
+
+			if (first_td) {
+				editor.s.setCursorIn(first_td);
+				scrollIntoViewIfNeeded(first_td, editor.editor, editor.ed);
+			}
+
+			close();
+		};
+
 		editor.e
-			.on(blocksContainer, 'mousemove', mouseenter)
+			.on(blocksContainer, 'mousemove', (e: MouseEvent) => {
+				if (Dom.isTag(e.target, 'span')) {
+					highlightCell(e.target);
+				}
+			})
 			.on(blocksContainer, 'touchstart mousedown', (e: MouseEvent) => {
-				const dv = e.target;
+				if (!Dom.isTag(e.target, 'span')) {
+					return;
+				}
+
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				insertTable(e.target);
+			})
+			.on(blocksContainer, 'keydown', (e: KeyboardEvent) => {
+				if (!Dom.isTag(e.target, 'span')) {
+					return;
+				}
+
+				if (e.key === KEY_ENTER) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					insertTable(e.target);
+					return;
+				}
+
+				if (e.key === KEY_ESC) {
+					e.preventDefault();
+					e.stopImmediatePropagation();
+					close();
+					return;
+				}
+
+				const index = parseInt(attr(e.target, '-index') || '0', 10),
+					row = Math.floor(index / default_cols_count),
+					col = index % default_cols_count;
+				let nextIndex = index;
+
+				switch (e.key) {
+					case KEY_LEFT:
+						nextIndex = col > 0 ? index - 1 : index;
+						break;
+					case KEY_RIGHT:
+						nextIndex =
+							col < default_cols_count - 1 ? index + 1 : index;
+						break;
+					case KEY_UP:
+						nextIndex =
+							row > 0 ? index - default_cols_count : index;
+						break;
+					case KEY_DOWN:
+						nextIndex =
+							row < default_rows_count - 1
+								? index + default_cols_count
+								: index;
+						break;
+					default:
+						return;
+				}
 
 				e.preventDefault();
 				e.stopImmediatePropagation();
 
-				if (!Dom.isTag(dv, 'span')) {
-					return;
+				if (nextIndex !== index) {
+					cells[index].tabIndex = -1;
+					cells[nextIndex].tabIndex = 0;
+					cells[nextIndex].focus();
+					highlightCell(cells[nextIndex]);
 				}
-
-				const k = parseInt(attr(dv, '-index') || '0', 10);
-
-				const rows_count = Math.ceil((k + 1) / default_cols_count),
-					cols_count = (k % default_cols_count) + 1;
-
-				const crt = editor.createInside,
-					tbody = crt.element('tbody'),
-					table = crt.element('table');
-
-				table.appendChild(tbody);
-
-				let first_td: HTMLTableCellElement | null = null,
-					tr: HTMLTableRowElement,
-					td: HTMLTableCellElement;
-
-				for (let i = 1; i <= rows_count; i += 1) {
-					tr = crt.element('tr');
-
-					for (let j = 1; j <= cols_count; j += 1) {
-						td = crt.element('td');
-
-						if (!first_td) {
-							first_td = td;
-						}
-
-						css(td, 'width', (100 / cols_count).toFixed(4) + '%');
-
-						td.appendChild(crt.element('br'));
-						tr.appendChild(crt.text('\n'));
-						tr.appendChild(crt.text('\t'));
-						tr.appendChild(td);
-					}
-
-					tbody.appendChild(crt.text('\n'));
-					tbody.appendChild(tr);
-				}
-
-				$$('input[type=checkbox]:checked', options).forEach(
-					(input: HTMLElement) => {
-						(input as HTMLInputElement).value
-							.split(/[\s]+/)
-							.forEach((className: string) => {
-								table.classList.add(className);
-							});
-					}
-				);
-
-				editor.s.restore();
-				editor.s.removeMarkers();
-				editor.editor.normalize();
-				editor.history.snapshot.restore(snapshot);
-
-				const block = Dom.furthest(
-					editor.s.current(),
-					Dom.isBlock,
-					editor.editor
-				);
-
-				if (block && Dom.isEmpty(block)) {
-					Dom.replace(block, table, undefined, false, true);
-				} else {
-					if (block) {
-						const fake = crt.text('\n');
-						if (!editor.o.table.splitBlockOnInsertTable) {
-							Dom.after(block, fake);
-							Dom.after(fake, table);
-						} else {
-							const range = editor.s.range;
-							range.collapse(false);
-							range.insertNode(fake);
-							range.collapse(false);
-							editor.s.selectRange(range);
-
-							const firstPart = editor.s.splitSelection(
-								block,
-								fake
-							);
-
-							if (firstPart) {
-								Dom.after(firstPart, table);
-							} else {
-								Dom.after(block, table);
-							}
-						}
-					} else {
-						editor.s.insertNode(table, false);
-					}
-				}
-
-				if (first_td) {
-					editor.s.setCursorIn(first_td);
-					scrollIntoViewIfNeeded(first_td, editor.editor, editor.ed);
-				}
-
-				close();
 			});
 
 		if (button && button.parentElement) {
 			for (let i = 0; i < default_rows_count; i += 1) {
 				const row = editor.c.div();
+				attr(row, 'role', 'row');
 
 				for (let j = 0; j < default_cols_count; j += 1) {
 					row.appendChild(cells[i * default_cols_count + j]);

--- a/src/plugins/table/table.test.js
+++ b/src/plugins/table/table.test.js
@@ -5,6 +5,75 @@
  */
 
 describe('Test table plugin', () => {
+	describe('Keyboard navigation in the table-size picker', () => {
+		it('should move through the grid with arrow keys and insert with Enter', () => {
+			const editor = getJodit({
+				disablePlugins: ['wrapNodes']
+			});
+			editor.value = '<p>test|</p>';
+			editor.focus();
+			setCursorToChar(editor);
+
+			clickButton('table', editor);
+			const popup = getOpenedPopup(editor);
+			const grid = popup.querySelector('.jodit-form__container');
+			const firstCell = grid.querySelector('span[data-index="0"]');
+
+			expect(grid.getAttribute('role')).eq('grid');
+			expect(firstCell.getAttribute('role')).eq('gridcell');
+			expect(firstCell.tabIndex).eq(0);
+			expect(grid.querySelectorAll('span[tabindex="0"]').length).eq(1);
+
+			firstCell.focus();
+			simulateEvent('keydown', Jodit.KEY_RIGHT, firstCell);
+
+			const secondCell = grid.querySelector('span[data-index="1"]');
+			expect(editor.ownerDocument.activeElement).eq(secondCell);
+			expect(secondCell.tabIndex).eq(0);
+			expect(firstCell.tabIndex).eq(-1);
+
+			simulateEvent('keydown', Jodit.KEY_DOWN, secondCell);
+
+			const selectedCell = grid.querySelector('span[data-index="11"]');
+			expect(editor.ownerDocument.activeElement).eq(selectedCell);
+			expect(popup.querySelector('.jodit-form__center').textContent).eq(
+				'2 × 2'
+			);
+
+			simulateEvent('keydown', Jodit.KEY_LEFT, selectedCell);
+			const previousCell = grid.querySelector('span[data-index="10"]');
+			expect(editor.ownerDocument.activeElement).eq(previousCell);
+
+			simulateEvent('keydown', Jodit.KEY_UP, previousCell);
+			expect(editor.ownerDocument.activeElement).eq(firstCell);
+
+			simulateEvent('keydown', Jodit.KEY_LEFT, firstCell);
+			simulateEvent('keydown', Jodit.KEY_UP, firstCell);
+			expect(editor.ownerDocument.activeElement).eq(firstCell);
+
+			simulateEvent('keydown', Jodit.KEY_RIGHT, firstCell);
+			simulateEvent('keydown', Jodit.KEY_DOWN, secondCell);
+
+			simulateEvent('keydown', Jodit.KEY_ENTER, selectedCell);
+
+			expect(editor.editor.querySelectorAll('table td').length).eq(4);
+			expect(getOpenedPopup(editor)).is.null;
+		});
+
+		it('should close the picker with Escape', () => {
+			const editor = getJodit();
+
+			clickButton('table', editor);
+			const popup = getOpenedPopup(editor);
+			const firstCell = popup.querySelector('span[data-index="0"]');
+
+			firstCell.focus();
+			simulateEvent('keydown', Jodit.KEY_ESC, firstCell);
+
+			expect(getOpenedPopup(editor)).is.null;
+		});
+	});
+
 	describe('Click button and click to some cell', () => {
 		it('should create and insert new table', () => {
 			const editor = getJodit({


### PR DESCRIPTION
## Summary

- expose the table-size picker as an accessible grid with a single tab stop
- move the active cell with bounded arrow-key navigation while keeping the size preview in sync
- insert the selected table with Enter and close the picker with Escape
- keep mouse and touch insertion on the same table-creation path

## Validation

- `make lint` (passes; four pre-existing warnings)
- `make test browsers=chrome_headless` (2,146 passed, 1 skipped)

Closes #1418