### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ const editor = Jodit.make('#editor', {
 
 ## Star History
 
-<a href="https://star-history.com/#xdan/jodit&Date">
-  <img src="https://api.star-history.com/svg?repos=xdan/jodit&type=Date" alt="Star History Chart" width="640">
+<a href="https://star-history.dera.page/#xdan/jodit&Date">
+  <img src="https://star-history.dera.page/svg?repos=xdan/jodit&type=Date" alt="Star History Chart" width="640">
 </a>
 
 ## License


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This changes the chart to a working endpoint so the repository star history renders correctly again.